### PR TITLE
Add Projects.md and semester 1 projects and boards

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,66 @@
+---
+slack_channel: https://gds.slack.com/archives/C05599LTS0J
+slack_channel_name: proj-early-talent-assigned-learning
+---
+
+# Semester 1
+
+## Projects
+
+### @antoni-devlin
+
+[Repo](https://github.com/alphagov/learningtime-ad-sem1-postcode-geocoder)
+
+[Project board](https://github.com/orgs/alphagov/projects/57)
+
+### @jyoung-gds
+
+[Repo](https://github.com/alphagov/learningtime-jy-sem1)
+
+[Project board](https://github.com/orgs/alphagov/projects/58)
+
+### @Rkotyank
+
+[Repo](https://github.com/alphagov/learningtime-rk-sem1)
+
+[Project board](https://github.com/orgs/alphagov/projects/59)
+
+### @Ryan-Andrews99
+
+[Repo](https://github.com/alphagov/learning-time-RA-sem1)
+
+[Project board](https://github.com/orgs/alphagov/projects/60)
+
+### @kashifatcha
+
+[Repo](https://github.com/alphagov/learningtime-ka-sem1)
+
+[Project Board](https://github.com/orgs/alphagov/projects/61)
+
+### @jonathan-ryding
+
+[Repo](https://github.com/alphagov/learningtime-jr-sem1)
+
+[Project board](https://github.com/orgs/alphagov/projects/62)
+
+### @PeterHattyar
+
+[Repo](https://github.com/alphagov/learningtime-ph-sem1)
+
+[Project Board](hhttps://github.com/orgs/alphagov/projects/64)
+
+### @DanielMurray97
+
+[Repo](https://github.com/alphagov/learningtime-dm-sem1-darkmode)
+
+[Project Board](https://github.com/orgs/alphagov/projects/63)
+
+### @Harrisman05
+
+[Repo](https://github.com/alphagov/learningtime-hh-sem1-gov-location-service)
+
+[Project Board](https://github.com/orgs/alphagov/projects/65)
+
+### @GDSNewt
+
+[Repo](https://github.com/alphagov/learningtime-an-sem1)


### PR DESCRIPTION
The focus of the learning time is built around projects. We asked candidates to create new github repositories for each project individually, and also create a project board on github.

Github Projects aren't usually used at GDS, however in this case as we have candidates spread across GDS teams that tend to use different tools (Trello / Jira etc), Github Projects was the easiest tool that we all already had access to.

This adds project boards and links to repos for semester 1 candidates. A couple are missing who will join or add data later, I will update this as we go.